### PR TITLE
Replace type of countunit to the right one

### DIFF
--- a/doc_source/LifecyclePolicies.md
+++ b/doc_source/LifecyclePolicies.md
@@ -24,7 +24,7 @@ The contents of your lifecycle policy is evaluated before being associated with 
                 "tagStatus": "tagged"|"untagged",
                 "tagPrefixList": list<string>,
                 "countType": "imageCountMoreThan"|"sinceImagePushed",
-                "countUnit": "integer",
+                "countUnit": string,
                 "countNumber": "integer"
             },
             "action": {


### PR DESCRIPTION
*Description of changes:*

Fixing the typo in documentation. `countType` is actually string and not integer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
