### PR TITLE
Fix query in example command

### DIFF
--- a/doc_source/retag-aws-cli.md
+++ b/doc_source/retag-aws-cli.md
@@ -10,7 +10,7 @@ This procedure does not work for Windows clients because of the way the AWS CLI 
 1. Use the batch\-get\-image command to get the image manifest for the image to retag and write it to an environment variable\. In this example, the manifest for an image with the tag, *latest*, in the repository, *amazonlinux*, is written to the environment variable, *MANIFEST*\.
 
    ```
-   MANIFEST=$(aws ecr batch-get-image --repository-name amazonlinux --image-ids imageTag=latest --query images[].imageManifest --output text)
+   MANIFEST=$(aws ecr batch-get-image --repository-name amazonlinux --image-ids imageTag=latest --query 'images[].imageManifest' --output text)
    ```
 
 1. Use the `--image-tag` option of the put\-image command to put the image manifest to Amazon ECR with a new tag\. In this example, the image is tagged as *2017\.03*\.


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
The 'Retagging an Image with the AWS CLI' example currently doesn't work. When you attempt to use the command in step 1, the returned value from AWS is:
`no matches found: images[].imageManifest`

Thankfully [this stack-overflow question](https://stackoverflow.com/questions/50261350/how-do-i-re-tag-an-image-in-ecr) had the answer. Adding the quotes around the query string makes this functional again.

Having eventually found the answer after struggling for a while, I figured better to fix the documentation so other's don't have the same problems!

Thanks go to [ido-levy](https://stackoverflow.com/users/9838856/ido-levy) and [justbaron](https://stackoverflow.com/users/715105/justbaron) for finding the fix in the first place.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
