### PR TITLE
Replaced convoluted instructions with actions

### DIFF
--- a/doc_source/ecr-supported-iam-actions-resources.md
+++ b/doc_source/ecr-supported-iam-actions-resources.md
@@ -6,9 +6,6 @@ The following table describes the Amazon ECR API operations that currently suppo
 
 For a list of Amazon ECR operations, see [Actions](http://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_Operations.html) in the *Amazon Elastic Container Registry API Reference*\.
 
-**Important**  
-If an Amazon ECR API operation is not listed in this table, then it does not support resource\-level permissions\. If an API operation does not support resource\-level permissions, you can grant users permission to use the operation, but you have to specify the \* \(asterisk\) wildcard for the resource element of your policy statement\.
-
 
 | API action | Resource | 
 | --- | --- | 
@@ -16,11 +13,13 @@ If an Amazon ECR API operation is not listed in this table, then it does not sup
 | BatchDeleteImage |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | BatchGetImage |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | CompleteLayerUpload |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
+| CreateRepository |  *  | 
 | DeleteLifecyclePolicy |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | DeleteRepository |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | DeleteRepositoryPolicy |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | DescribeImages |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | DescribeRepositories |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
+| GetAuthorizationToken |  *  | 
 | GetDownloadUrlForLayer |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | GetLifecyclePolicy |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 
 | GetLifecyclePolicyPreview |  Repository arn:aws:ecr:*region*:*account*:repository/*my\-repo*  | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The reader is instructed to figure out if an action doesn't support a resource constraint by comparing the full list of actions (on another page) to the list in the table. The actions _not_ in the list do not support a resource constraint.

I removed those instructions and simply added 2 rows for the actions that _do not_ support the resource action. This makes it much easier for the read to know exactly which actions support the resource actions and which do not.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
