### PR TITLE
Adding needed endpoint to the documentation

### DIFF
--- a/doc_source/vpc-endpoints.md
+++ b/doc_source/vpc-endpoints.md
@@ -9,6 +9,7 @@ For more information about PrivateLink and VPC endpoints, see [Accessing AWS Ser
 + [Creating the VPC Endpoint for Amazon ECR](#ecr-setting-up-vpc-create)
 + [Creating the Amazon S3 Gateway Endpoint](#ecr-setting-up-s3-gateway)
 + [Minimum Amazon S3 Bucket Permissions for Amazon ECR](ecr-minimum-s3-perms.md)
++ [Creating the VPC Endpoint for Amazon CloudWatch Logs](#cwlogs-setting-up-vpc-create)
 
 ## Considerations for Amazon ECR VPC Endpoints<a name="ecr-vpc-endpoint-considerations"></a>
 
@@ -21,6 +22,7 @@ Amazon ECS tasks that use the Fargate launch type don't require the Amazon ECS i
 + VPC endpoints only support Amazon\-provided DNS through Amazon Route 53\. If you want to use your own DNS, you can use conditional DNS forwarding\. For more information, see [DHCP Options Sets](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html) in the *Amazon VPC User Guide*\.
 + The security group attached to the VPC endpoint must allow incoming connections on port 443 from the private subnet of the VPC\.
 + When you create the Amazon S3 gateway endpoint, if your containers have existing connections to Amazon S3, their connections might be briefly interrupted while the gateway is being added\. If you want to avoid this interruption, create a new VPC that uses the Amazon S3 gateway endpoint and then migrate your Amazon ECS cluster and its containers into the new VPC\.
++ Remember to add the CloudWatch Logs interface endpoint. This is a must, given that all tasks at the service level are going to be using CloudWatch Logs as a log repository.
 
 ## Creating the VPC Endpoint for Amazon ECR<a name="ecr-setting-up-vpc-create"></a>
 
@@ -57,3 +59,12 @@ To create the Amazon S3 gateway endpoint for the Amazon ECR service, use the [Cr
 
 **com\.amazonaws\.*region*\.s3**  
 The Amazon S3 gateway endpoint uses an IAM policy document to limit access to the service\. The **Full Access** policy can be used because any restrictions that you have put in your task IAM roles or other IAM user policies still apply on top of this policy\. If you want to limit Amazon S3 bucket access to the minimum required permissions required to use Amazon ECR, see [Minimum Amazon S3 Bucket Permissions for Amazon ECR](ecr-minimum-s3-perms.md)\.
+
+## Creating the VPC Endpoint for Amazon CloudWatch Logs<a name="cwlogs-vpc-endpoint-considerations"></a>
+
+This interface endpoint is required for all ECS tasks to insert logs on a CloudWatch Logs stream. When your container initializes, the task puts logs on a CloudWatch Logs and not having this endpoint is going to result on ECS to not be able to move the task from provisioning to running.
+
+To create the VPC endpoint for the Amazon Cloudwatch Logs service, use the [Creating an Interface Endpoint](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) procedure in the *Amazon VPC User Guide* to create the endpoints described here\.
+
+The required endpoint to accomplish connection from your VPC to CloudWatch Logs is **com\.amazonaws\.*region*\.logs**   
+


### PR DESCRIPTION
I was creating a demo for a customer that requested private access from its ECS cluster to launch a fargate task using a private connection to ECR. I had to create a CloudWatch Logs endpoint too even using a base nginx image. This is missing from the documentation so I´m adding it

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
