### PR TITLE
Correction to sample IAM policy

### DIFF
--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -109,7 +109,6 @@ In this example, you want to grant an IAM user in your AWS account access to one
          "Sid":"ManageRepositoryContents",
          "Effect":"Allow",
          "Action":[
-                "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:GetRepositoryPolicy",
@@ -123,6 +122,14 @@ In this example, you want to grant an IAM user in your AWS account access to one
                 "ecr:PutImage"
          ],
          "Resource":"arn:aws:ecr:us-east-1:123456789012:repository/my-repo"
+      },
+      {
+        "Sid":"GetAuthorizationToken",
+        "Effect": "Allow",
+        "Action": [
+            "ecr:GetAuthorizationToken"
+        ],
+        "Resource": "*"
       }
    ]
 }


### PR DESCRIPTION
Correction to the example IAM policy titled "Accessing One Amazon ECR Repository"

"ecr:GetAuthorizationToken" does not support resource level permissions, and should be split out to a separate block with "Resource": "*"

Without the correction, attempting to run `aws ecr get-login --no-include-email` will return with an error such as:
An error occurred (AccessDeniedException) when calling the GetAuthorizationToken operation: User: <user-arn> is not authorized to perform: ecr:GetAuthorizationToken on resource: *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
