### PR TITLE
ECR Repository does not support Resource attribute

### DIFF
--- a/doc_source/RepositoryPolicyExamples.md
+++ b/doc_source/RepositoryPolicyExamples.md
@@ -147,7 +147,7 @@ The following repository policy denies all users the ability to pull images\.
 
 ## Example: Restricting Access to Specific IP Addresses<a name="IAM_restrict_ip"></a>
 
-The following example grants permissions to any user to perform any Amazon ECR operations on the specified repository\. However, the request must originate from the range of IP addresses specified in the condition\.
+The following example grants permissions to any user to perform any Amazon ECR operations when applied to a repository\. However, the request must originate from the range of IP addresses specified in the condition\.
 
 The condition in this statement identifies the `54.240.143.*` range of allowed Internet Protocol version 4 \(IPv4\) IP addresses, with one exception: `54.240.143.188`\.
 
@@ -163,7 +163,6 @@ The `Condition` block uses the `IpAddress` and `NotIpAddress` conditions and the
       "Effect": "Allow",
       "Principal": "*",
       "Action": "ecr:*",
-      "Resource": "arn:aws:ecr:us-east-1:123456789012:repository/my-repo",
       "Condition": {
                 "NotIpAddress": {
                     "aws:SourceIp": "54.240.143.188/32"


### PR DESCRIPTION
*Issue #, if available:*

[Amazon ECR Repository Policy Examples - Example: Restricting Access to Specific IP Addresses/RepositoryPolicyExamples.html#IAM_restrict_ip](https://docs.aws.amazon.com/AmazonECR/latest/userguide) describes ability to apply ECR Repository policy with a `Resource` attribute. This is currently not supported and if supplied will result in the following error message

> Invalid parameter at 'PolicyText' failed to satisfy constraint: 'Invalid repository policy provided'

Applying the same policy without `Resource` will result in the policy successfully being applied.

*Description of changes:*

The following changes were made within [Amazon ECR Repository Policy Examples - Example: Restricting Access to Specific IP Addresses/RepositoryPolicyExamples.html#IAM_restrict_ip](https://docs.aws.amazon.com/AmazonECR/latest/userguide)

- Remove `Resource` attribute and value from example.
- Updated example introductory text to clarify that this policy is being applied to the target repository and is not specifying a target repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
