### PR TITLE
make authentication clearer

### DIFF
--- a/doc_source/getting-started-cli.md
+++ b/doc_source/getting-started-cli.md
@@ -144,7 +144,7 @@ Output from the Apache web server is displayed in the terminal window\. You can 
 
 After you have installed and configured the AWS CLI, authenticate the Docker CLI to your default registry\. That way, the docker command can push and pull images with Amazon ECR\. The AWS CLI provides a get\-login\-password command to simplify the authentication process\.
 
-To authenticate Docker to an Amazon ECR registry with get\-login\-password, run the aws ecr get\-login\-password command\. When passing the authentication token to the docker login command, you specify the `AWS` username and the Amazon ECR registry URI you want to authenticate to\. If authenticating to multiple registries, you must repeat the command for each registry\.
+To authenticate Docker to an Amazon ECR registry with get\-login\-password, run the aws ecr get\-login\-password command\. When passing the authentication token to the docker login command, you specify the username `AWS` and the Amazon ECR registry URI you want to authenticate to\. If authenticating to multiple registries, you must repeat the command for each registry\.
 **Important**  
 If you receive an error, install or upgrade to the latest version of the AWS CLI\. For more information, see [Installing the AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) in the *AWS Command Line Interface User Guide*\.
 + [get\-login\-password](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html) \(AWS CLI\)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I read `you specify the AWS username` I misread it as meaning you that you need to specify your AWS username. Switching the order should make it more clear that you literally need to specify `AWS` as the username.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
