### PR TITLE
Fix incorrect sid

### DIFF
--- a/doc_source/repository-policies.md
+++ b/doc_source/repository-policies.md
@@ -38,7 +38,7 @@ This example shows an IAM policy that achieves the same goal as above, by scopin
 {
   "Version": "2012-10-17",
   "Statement": [{
-    "Sid": "ECR Repository Policy",
+    "Sid": "ECRRepositoryPolicy",
     "Effect": "Allow",
     "Principal": {
       "AWS": "arn:aws:iam::account-id:user/username"


### PR DESCRIPTION
Sids are not allowed to have spaces in iam policies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
