### PR TITLE
Update get-set-up-for-amazon-ecr.md

### DIFF
--- a/doc_source/get-set-up-for-amazon-ecr.md
+++ b/doc_source/get-set-up-for-amazon-ecr.md
@@ -1,6 +1,6 @@
 # Setting up with Amazon ECR<a name="get-set-up-for-amazon-ecr"></a>
 
-If you've signed up for AWS and have been using Amazon Elastic Container Service \(Amazon ECS\) or Amazon Elastic Kubernetes Service \(Amazon EKS\), you are close to being able to use Amazon ECR\. The setup process for these two services is similar, as Amazon ECR is an extension to these services\. To use the AWS CLI with Amazon ECR, you must use a version of the AWS CLI that supports the latest Amazon ECR features\. If you do not see support for an Amazon ECR feature in the AWS CLI, you should upgrade to the latest version\. For more information, see [http://aws\.amazon\.com/cli/](http://aws.amazon.com/cli/)\.
+If you've signed up for AWS and have been using Amazon Elastic Container Service \(Amazon ECS\) or Amazon Elastic Kubernetes Service \(Amazon EKS\), you are close to being able to use Amazon ECR\. The setup process for those two services is similar, as Amazon ECR is an extension to both services\. When using the AWS CLI with Amazon ECR, we recommend you use a version of the AWS CLI that supports the latest Amazon ECR features\. If you do not see support for an Amazon ECR feature in the AWS CLI, you should upgrade to the latest version\. For more information, see [http://aws\.amazon\.com/cli/](http://aws.amazon.com/cli/)\.
 
 Complete the following tasks to get set up to push a container image to Amazon ECR for the first time\. If you have already completed any of these steps, you may skip them and move on to the next step\.
 


### PR DESCRIPTION
On line #3  "these" should be replaced with "those". For example, the following sentence uses those "If you attend high school A or high school B, you have a better shot of getting into Harvard because those two schools offer advanced placement classes." 
At the end of the sentence I used the word "both" rather than using "those" again. 

Also on #3 the "must" should be changed to "we recommend". This is because the CLI will still work for basic ECR features but it may not have commands for the latest features. As an alternative, the word "should" could replace "must". I chose "We recommend" because "should" is used in the next sentence. 

Thank you for taking the time to review my proposed changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
