### PR TITLE
Clarify use of "tag" when referring to AWS resource tags, not Docker image tags

### DIFF
--- a/doc_source/ecr-using-tags.md
+++ b/doc_source/ecr-using-tags.md
@@ -1,6 +1,6 @@
 # Tagging an Amazon ECR repository<a name="ecr-using-tags"></a>
 
-To help you manage your Amazon ECR repositories, you can optionally assign your own metadata to each repository in the form of *tags*\. This topic describes tags and shows you how to create them\.
+To help you manage your Amazon ECR repositories, you can optionally assign your own metadata to each repository in the form of *tags*\. This topic describes tags and shows you how to create them\. To be clear, this page is about AWS resource tags, not Docker image tags.
 
 **Topics**
 + [Tag basics](#tag-basics)


### PR DESCRIPTION
*Description of changes:*

Clarify use of the word "tag" in a context in which people will take incorrect shortcuts.

Commit message: `Use of the word "tag" in this context requires an explicit clarification, otherwise ordinary, flawed people (like me, just now) will get confused.`