### PR TITLE
Updated incorrect information about the max destinations per rule in cross account replication configuration

### DIFF
--- a/doc_source/registry-settings-configure.md
+++ b/doc_source/registry-settings-configure.md
@@ -28,7 +28,7 @@ For cross\-account replication to occur, the destination account must configure 
 
 **To configure registry replication settings \(AWS CLI\)**
 
-1. Create a JSON file containing the replication rules to define for your registry\. A replication configuration may contain up to 10 rules, with each rule specifying up to 25 destinations and 100 filters\. To configure cross\-Region replication within your own account, you specify your own account ID\. For more examples, see [Private image replication examples](registry-settings-examples.md)\.
+1. Create a JSON file containing the replication rules to define for your registry\. A replication configuration may contain up to 10 rules, with up to 25 unique destinations across all rules and 100 filters per rule\. To configure cross\-Region replication within your own account, you specify your own account ID\. For more examples, see [Private image replication examples](registry-settings-examples.md)\.
 
    ```
    {


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
The current information about the number of destinations in the registry-settings-configure.md is incorrect. 
```A replication configuration may contain up to 10 rules, with each rule specifying up to 25 destinations and 100 filters.```

As per this [doc](https://docs.aws.amazon.com/AmazonECR/latest/userguide/replication.html#replication-considerations) ECR doesn't support more than 25 destinations across all the rules for cross account replication. I have also tested this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
