### PR TITLE
Fix in batch-get-image CLI command to prevent newline changing image …

### DIFF
--- a/doc_source/image-retag.md
+++ b/doc_source/image-retag.md
@@ -9,7 +9,7 @@ With Docker Image Manifest V2 Schema 2 images, you can use the `--image-tag` opt
 1. Use the batch\-get\-image command to get the image manifest for the image to retag and write it to a file\. In this example, the manifest for an image with the tag, *latest*, in the repository, *amazonlinux*, is written to an environment variable named *MANIFEST*\.
 
    ```
-   MANIFEST=$(aws ecr batch-get-image --repository-name amazonlinux --image-ids imageTag=latest --output json | jq --raw-output '.images[0].imageManifest')
+   MANIFEST=$(aws ecr batch-get-image --repository-name amazonlinux --image-ids imageTag=latest --output json | jq --raw-output --join-output '.images[0].imageManifest')
    ```
 
 1. Use the `--image-tag` option of the put\-image command to put the image manifest to Amazon ECR with a new tag\. In this example, the image is tagged as *2017\.03*\.


### PR DESCRIPTION
…digest

*Issue #, if available:*
Fixes #51

*Description of changes:*
`aws ecr batch-get-image...` command in https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-retag.html includes jq command, which adds a newline character to the manifest and changes the image digest. Including --join-output in the jq command as an argument prevents the newline character and preserves the image digest from changing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
