### PR TITLE
Changes to Cross-Account Replication

### DIFF
--- a/doc_source/replication.md
+++ b/doc_source/replication.md
@@ -6,7 +6,7 @@ Amazon ECR uses **registry settings** to configure private image replication at 
 Enabling cross\-Region replication for your registry makes copies of the repositories in one or more destination Regions\. Only images pushed to a repository after cross\-Region replication is configured are copied\.
 
 **Cross\-account replication**  
-Enabling cross\-account replication for your registry makes copies of the repositories in the destination account and Regions you specify\. For cross\-account replication to occur, the destination account must configure a registry permissions policy to allow replication from your registry to occur\. For more information, see [Private registry permissions](registry-permissions.md)\.
+Enabling cross\-account replication for your registry makes copies of the repositories in the destination account and Regions you specify\. Only images pushed to a repository after cross\-account replication is configured are copied\. For cross\-account replication to occur, the destination account must configure a registry permissions policy to allow replication from your registry to occur\. For more information, see [Private registry permissions](registry-permissions.md)\.
 
 **Topics**
 + [Considerations for private image replication](#replication-considerations)


### PR DESCRIPTION
The images will be replicated in Cross-Account only after cross-account replication is configured .

*Issue #, if available:* Addition of information under Cross-Account Image replication

*Description of changes:*
The information about replication of only new images after cross-region replication configuration is enabled is specified. However the same applies to the cross-account replication as well. Already Existing images before replication configuration are not copied. This information is not mentioned in the documentation under cross-account.

Have tested this functionality in my AWS account and confirmed that already Existing images before replication configuration are not copied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
